### PR TITLE
Declare Java compatibility in a single line

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,10 +15,7 @@ version = "1.4"
 group = "com.llamalad7.betterchat" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "betterchat"
 
-sourceCompatibility = targetCompatibility = '1.8' // Need this here so eclipse task generates correctly.
-compileJava {
-    sourceCompatibility = targetCompatibility = '1.8'
-}
+sourceCompatibility = targetCompatibility = compileJava.sourceCompatibility = compileJava.targetCompatibility =  JavaVersion.VERSION_1_8 // Need this here so eclipse task generates correctly.
 
 minecraft {
     version = "1.12.2-14.23.5.2847"


### PR DESCRIPTION
We are those guys who don't need 4 lines to write ONLY the Java compatibility. Oh, great LlamaLad7, I know that you have this method somewhere in your mind. But you didn't bother to implement the same method that you used in the '1.8.9' branch. Anyway, I am suggesting you merge this code. Pls pls pls. I request you. Humble request. Earnest request. Plzzzz.